### PR TITLE
Implement single-instance activation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,7 @@
 #include <QApplication>
 #include <QStyleFactory>
+#include <QLocalServer>
+#include <QLocalSocket>
 #include "mainwindow.h"
 #include "config.h"
 #include "logger.h"
@@ -7,6 +9,23 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+
+    // 单实例检查
+    const QString serverName = "TranslatorSingleInstance";
+    QLocalSocket socket;
+    socket.connectToServer(serverName);
+    if (socket.waitForConnected(100)) {
+        // 已有实例在运行，通知其激活并退出
+        socket.write("activate");
+        socket.flush();
+        socket.waitForBytesWritten(100);
+        socket.disconnectFromServer();
+        return 0;
+    }
+
+    QLocalServer server;
+    QLocalServer::removeServer(serverName);
+    server.listen(serverName);
     
     // 初始化日志系统
     Logger::instance()->setLogLevel(LOG_INFO);
@@ -27,6 +46,19 @@ int main(int argc, char *argv[])
     
     // 创建并显示主窗口
     MainWindow window;
+
+    QObject::connect(&server, &QLocalServer::newConnection, [&window, &server]() {
+        QLocalSocket *client = server.nextPendingConnection();
+        if (client) {
+            client->readAll();
+            client->close();
+            client->deleteLater();
+        }
+        window.show();
+        window.raise();
+        window.activateWindow();
+    });
+
     window.show();
     
     LOG_INFO("主窗口显示完成，进入事件循环", "Main");


### PR DESCRIPTION
## Summary
- enforce single-instance mode using `QLocalServer`/`QLocalSocket`
- activate existing window when launching a second instance

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6856cc7b7ac8833190ac1bd00410a0cf