### PR TITLE
Simplify logging

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,6 +4,8 @@
 #include <QCoreApplication>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QThread>
+#include <QFileInfo>
 
 Logger* Logger::m_instance = nullptr;
 QMutex Logger::m_mutex;
@@ -28,13 +30,13 @@ Logger::Logger(QObject *parent)
         }
     }
     
-    info("日志系统初始化完成", "Logger");
+    info("日志系统初始化完成", __FILE__, __LINE__);
 }
 
 Logger::~Logger()
 {
     if (m_logFile.isOpen()) {
-        info("日志系统关闭", "Logger");
+        info("日志系统关闭", __FILE__, __LINE__);
         m_logFile.close();
     }
 }
@@ -50,92 +52,43 @@ Logger* Logger::instance()
     return m_instance;
 }
 
-void Logger::debug(const QString &message, const QString &module)
+void Logger::debug(const QString &message,
+                   const char *file, int line)
 {
-    writeLog(LOG_DEBUG, message, module);
+    writeLog(LOG_DEBUG, message, file, line);
 }
 
-void Logger::info(const QString &message, const QString &module)
+void Logger::info(const QString &message,
+                  const char *file, int line)
 {
-    writeLog(LOG_INFO, message, module);
+    writeLog(LOG_INFO, message, file, line);
 }
 
-void Logger::warning(const QString &message, const QString &module)
+void Logger::warning(const QString &message,
+                     const char *file, int line)
 {
-    writeLog(LOG_WARNING, message, module);
+    writeLog(LOG_WARNING, message, file, line);
 }
 
-void Logger::error(const QString &message, const QString &module)
+void Logger::error(const QString &message,
+                   const char *file, int line)
 {
-    writeLog(LOG_ERROR, message, module);
+    writeLog(LOG_ERROR, message, file, line);
 }
 
-void Logger::critical(const QString &message, const QString &module)
+void Logger::critical(const QString &message,
+                      const char *file, int line)
 {
-    writeLog(LOG_CRITICAL, message, module);
+    writeLog(LOG_CRITICAL, message, file, line);
 }
 
-void Logger::logTranslationStart(const QString &text, const QString &fromLang, const QString &toLang)
-{
-    QString message = QString("开始翻译 - 文本长度: %1, 从: %2, 到: %3")
-                     .arg(text.length()).arg(fromLang).arg(toLang);
-    info(message, "Translation");
-}
 
-void Logger::logTranslationSuccess(const QString &originalText, const QString &translatedText, 
-                                  const QString &fromLang, const QString &toLang, const QString &detectedLang)
-{
-    QString message = QString("翻译成功 - 原文长度: %1, 译文长度: %2, 检测语言: %3")
-                     .arg(originalText.length()).arg(translatedText.length()).arg(detectedLang);
-    info(message, "Translation");
-}
-
-void Logger::logTranslationError(const QString &text, const QString &error, const QString &fromLang, const QString &toLang)
-{
-    QString message = QString("翻译失败 - 文本长度: %1, 错误: %2")
-                     .arg(text.length()).arg(error);
-    this->error(message, "Translation");
-}
-
-void Logger::logApiCall(const QString &url, const QString &params)
-{
-    QString message = QString("API调用 - URL: %1, 参数长度: %2")
-                     .arg(url).arg(params.length());
-    debug(message, "API");
-}
-
-void Logger::logApiResponse(const QString &response, bool success)
-{
-    QString message = QString("API响应 - 成功: %1, 响应长度: %2")
-                     .arg(success ? "是" : "否").arg(response.length());
-    
-    if (success) {
-        debug(message, "API");
-    } else {
-        error(message, "API");
-    }
-}
-
-void Logger::logUserAction(const QString &action, const QString &details)
-{
-    QString message = QString("用户操作 - %1: %2").arg(action).arg(details);
-    info(message, "UserAction");
-}
-
-void Logger::logSettingsChange(const QString &setting, const QString &oldValue, const QString &newValue)
-{
-    QString message = QString("设置变更 - %1: %2 -> %3")
-                     .arg(setting)
-                     .arg(oldValue.isEmpty() ? "空" : "***")
-                     .arg(newValue.isEmpty() ? "空" : "***");
-    info(message, "Settings");
-}
-
-void Logger::writeLog(LogLevel level, const QString &message, const QString &module)
+void Logger::writeLog(LogLevel level, const QString &message,
+                      const char *file, int line)
 {
     if (level < m_currentLevel) return;
-    
-    QString formattedMessage = formatMessage(level, message, module);
+
+    QString formattedMessage = formatMessage(level, message, file, line);
     
     QMutexLocker locker(&m_writeMutex);
     
@@ -168,13 +121,24 @@ QString Logger::levelToString(LogLevel level)
     }
 }
 
-QString Logger::formatMessage(LogLevel level, const QString &message, const QString &module)
+QString Logger::formatMessage(LogLevel level, const QString &message,
+                              const char *file, int line)
 {
     QString timestamp = QDateTime::currentDateTime().toString(QString::fromUtf8(Config::LOG_DATE_FORMAT));
     QString levelStr = levelToString(level);
-    
-    return QString("[%1] [%2] [%3] %4")
-           .arg(timestamp).arg(levelStr).arg(module).arg(message);
+    QString threadId = QString::number(reinterpret_cast<quintptr>(QThread::currentThreadId()));
+    QString fileName;
+    if (file) {
+        fileName = QFileInfo(QString::fromUtf8(file)).fileName();
+    }
+
+    return QString("[%1] [%2] [%3:%4] [T:%5] %6")
+           .arg(timestamp)
+           .arg(levelStr)
+           .arg(fileName)
+           .arg(line)
+           .arg(threadId)
+           .arg(message);
 }
 
 void Logger::ensureLogDirectory()

--- a/src/logger.h
+++ b/src/logger.h
@@ -25,21 +25,17 @@ public:
     static Logger* instance();
     
     // 日志记录方法
-    void debug(const QString &message, const QString &module = "General");
-    void info(const QString &message, const QString &module = "General");
-    void warning(const QString &message, const QString &module = "General");
-    void error(const QString &message, const QString &module = "General");
-    void critical(const QString &message, const QString &module = "General");
-    
-    // 业务流程日志
-    void logTranslationStart(const QString &text, const QString &fromLang, const QString &toLang);
-    void logTranslationSuccess(const QString &originalText, const QString &translatedText, 
-                              const QString &fromLang, const QString &toLang, const QString &detectedLang);
-    void logTranslationError(const QString &text, const QString &error, const QString &fromLang, const QString &toLang);
-    void logApiCall(const QString &url, const QString &params);
-    void logApiResponse(const QString &response, bool success);
-    void logUserAction(const QString &action, const QString &details = "");
-    void logSettingsChange(const QString &setting, const QString &oldValue, const QString &newValue);
+    void debug(const QString &message,
+               const char *file = nullptr, int line = 0);
+    void info(const QString &message,
+              const char *file = nullptr, int line = 0);
+    void warning(const QString &message,
+                 const char *file = nullptr, int line = 0);
+    void error(const QString &message,
+               const char *file = nullptr, int line = 0);
+    void critical(const QString &message,
+                  const char *file = nullptr, int line = 0);
+
     
     // 配置方法
     void setLogLevel(LogLevel level);
@@ -54,9 +50,11 @@ private:
     explicit Logger(QObject *parent = nullptr);
     ~Logger();
     
-    void writeLog(LogLevel level, const QString &message, const QString &module);
+    void writeLog(LogLevel level, const QString &message,
+                  const char *file, int line);
     QString levelToString(LogLevel level);
-    QString formatMessage(LogLevel level, const QString &message, const QString &module);
+    QString formatMessage(LogLevel level, const QString &message,
+                          const char *file, int line);
     void ensureLogDirectory();
     
     static Logger* m_instance;
@@ -75,18 +73,15 @@ private:
 };
 
 // 便捷宏定义
-#define LOG_DEBUG(msg, module) Logger::instance()->debug(msg, module)
-#define LOG_INFO(msg, module) Logger::instance()->info(msg, module)
-#define LOG_WARNING(msg, module) Logger::instance()->warning(msg, module)
-#define LOG_ERROR(msg, module) Logger::instance()->error(msg, module)
-#define LOG_CRITICAL(msg, module) Logger::instance()->critical(msg, module)
-
-#define LOG_TRANSLATION_START(text, from, to) Logger::instance()->logTranslationStart(text, from, to)
-#define LOG_TRANSLATION_SUCCESS(orig, trans, from, to, detected) Logger::instance()->logTranslationSuccess(orig, trans, from, to, detected)
-#define LOG_TRANSLATION_ERROR(text, error, from, to) Logger::instance()->logTranslationError(text, error, from, to)
-#define LOG_API_CALL(url, params) Logger::instance()->logApiCall(url, params)
-#define LOG_API_RESPONSE(response, success) Logger::instance()->logApiResponse(response, success)
-#define LOG_USER_ACTION(action, details) Logger::instance()->logUserAction(action, details)
-#define LOG_SETTINGS_CHANGE(setting, oldVal, newVal) Logger::instance()->logSettingsChange(setting, oldVal, newVal)
+#define LOG_DEBUG(msg) \
+    Logger::instance()->debug(msg, __FILE__, __LINE__)
+#define LOG_INFO(msg) \
+    Logger::instance()->info(msg, __FILE__, __LINE__)
+#define LOG_WARNING(msg) \
+    Logger::instance()->warning(msg, __FILE__, __LINE__)
+#define LOG_ERROR(msg) \
+    Logger::instance()->error(msg, __FILE__, __LINE__)
+#define LOG_CRITICAL(msg) \
+    Logger::instance()->critical(msg, __FILE__, __LINE__)
 
 #endif // LOGGER_H 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
     Logger::instance()->setLogToFile(true);
     Logger::instance()->setLogToConsole(true);
     
-    LOG_INFO("应用程序启动", "Main");
+    LOG_INFO("应用程序启动");
     
     // 设置应用信息
     app.setApplicationName(Config::APP_NAME_STR);
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     // 设置应用样式
     app.setStyle(QStyleFactory::create("Fusion"));
     
-    LOG_INFO("创建主窗口", "Main");
+    LOG_INFO("创建主窗口");
     
     // 创建并显示主窗口
     MainWindow window;
@@ -61,11 +61,11 @@ int main(int argc, char *argv[])
 
     window.show();
     
-    LOG_INFO("主窗口显示完成，进入事件循环", "Main");
+    LOG_INFO("主窗口显示完成，进入事件循环");
     
     int result = app.exec();
     
-    LOG_INFO("应用程序退出", "Main");
+    LOG_INFO("应用程序退出");
     
     return result;
 } 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,14 +22,14 @@ MainWindow::MainWindow(QWidget *parent)
     , m_translator(new Translator(this))
     , m_settings(nullptr)
 {
-    LOG_DEBUG("主窗口构造函数开始", "MainWindow");
+    LOG_DEBUG("主窗口构造函数开始");
     
     // 设置配置文件路径到exe同级目录
     QString exePath = QCoreApplication::applicationDirPath();
     QString configPath = exePath + "/translator.ini";
     m_settings = new QSettings(configPath, QSettings::IniFormat, this);
     
-    LOG_INFO(QString("配置文件路径: %1").arg(configPath), "MainWindow");
+    LOG_INFO(QString("配置文件路径: %1").arg(configPath));
     
     setupUi();
     setupConnections();
@@ -47,19 +47,19 @@ MainWindow::MainWindow(QWidget *parent)
     int y = (screenGeometry.height() - height()) / 2;
     move(x, y);
     
-    LOG_DEBUG("主窗口构造函数完成", "MainWindow");
-    LOG_USER_ACTION("应用启动", "主窗口创建完成");
+    LOG_DEBUG("主窗口构造函数完成");
+    LOG_INFO("应用启动 - 主窗口创建完成");
 }
 
 MainWindow::~MainWindow()
 {
-    LOG_INFO("主窗口销毁", "MainWindow");
+    LOG_INFO("主窗口销毁");
     saveSettings();
 }
 
 void MainWindow::setupUi()
 {
-    LOG_DEBUG("开始设置UI", "MainWindow");
+    LOG_DEBUG("开始设置UI");
     
     m_centralWidget = new QWidget(this);
     setCentralWidget(m_centralWidget);
@@ -312,12 +312,12 @@ void MainWindow::setupUi()
         "}"
     );
     
-    LOG_DEBUG("UI设置完成", "MainWindow");
+    LOG_DEBUG("UI设置完成");
 }
 
 void MainWindow::setupConnections()
 {
-    LOG_DEBUG("开始设置信号连接", "MainWindow");
+    LOG_DEBUG("开始设置信号连接");
     
     // 连接翻译器信号
     connect(m_translator, &Translator::translationFinished,
@@ -331,12 +331,12 @@ void MainWindow::setupConnections()
     connect(m_testApiButton, &QPushButton::clicked, this, &MainWindow::onTestApiClicked);
     connect(m_swapButton, &QPushButton::clicked, this, &MainWindow::onSwapLanguagesClicked);
     
-    LOG_DEBUG("信号连接设置完成", "MainWindow");
+    LOG_DEBUG("信号连接设置完成");
 }
 
 void MainWindow::updateLanguageComboBoxes()
 {
-    LOG_DEBUG("更新语言选择框", "MainWindow");
+    LOG_DEBUG("更新语言选择框");
     
     m_fromLanguageCombo->clear();
     m_toLanguageCombo->clear();
@@ -350,14 +350,14 @@ void MainWindow::updateLanguageComboBoxes()
     m_fromLanguageCombo->setCurrentText("自动检测");
     m_toLanguageCombo->setCurrentText("英语");
     
-    LOG_INFO(QString("语言选择框已更新，支持 %1 种语言").arg(Config::LANGUAGE_NAMES.size()), "MainWindow");
+    LOG_INFO(QString("语言选择框已更新，支持 %1 种语言").arg(Config::LANGUAGE_NAMES.size()));
 }
 
 void MainWindow::onTranslateClicked()
 {
     QString text = m_inputTextEdit->toPlainText().trimmed();
     if (text.isEmpty()) {
-        LOG_USER_ACTION("翻译按钮点击", "输入文本为空");
+        LOG_INFO("翻译按钮点击 - 输入文本为空");
         showError("请输入要翻译的文本");
         return;
     }
@@ -365,10 +365,10 @@ void MainWindow::onTranslateClicked()
     QString fromLang = getLanguageCode(m_fromLanguageCombo->currentText());
     QString toLang = getLanguageCode(m_toLanguageCombo->currentText());
     
-    LOG_USER_ACTION("翻译按钮点击", QString("文本长度: %1, 从: %2, 到: %3").arg(text.length()).arg(fromLang).arg(toLang));
+    LOG_INFO(QString("翻译按钮点击 - 文本长度: %1, 从: %2, 到: %3").arg(text.length()).arg(fromLang).arg(toLang));
     
     if (!m_translator->isApiConfigured()) {
-        LOG_WARNING("API未配置", "MainWindow");
+        LOG_WARNING("API未配置");
         showError("请先配置API密钥");
         return;
     }
@@ -380,7 +380,7 @@ void MainWindow::onTranslateClicked()
     m_progressBar->setRange(0, 0); // 无限进度条
     m_statusLabel->setText("正在翻译...");
     
-    LOG_INFO("开始翻译请求", "MainWindow");
+    LOG_INFO("开始翻译请求");
     
     // 开始翻译
     m_translator->translateText(text, fromLang, toLang);
@@ -388,7 +388,7 @@ void MainWindow::onTranslateClicked()
 
 void MainWindow::onTranslationFinished(const QString &translatedText, const QString &detectedLang)
 {
-    LOG_DEBUG("翻译完成", "MainWindow");
+    LOG_DEBUG("翻译完成");
     
     m_outputTextEdit->setText(translatedText);
     m_progressBar->setVisible(false);
@@ -407,12 +407,12 @@ void MainWindow::onTranslationFinished(const QString &translatedText, const QStr
         showInfo(message);
     }
     
-    LOG_USER_ACTION("翻译完成", QString("翻译结果: %1").arg(translatedText.left(50)));
+    LOG_INFO(QString("翻译完成 - 翻译结果: %1").arg(translatedText.left(50)));
 }
 
 void MainWindow::onTranslationError(const QString &errorMessage)
 {
-    LOG_ERROR("翻译失败", errorMessage);
+    LOG_ERROR(QString("翻译失败: %1").arg(errorMessage));
     
     m_progressBar->setVisible(false);
     m_translateButton->setEnabled(true);
@@ -428,7 +428,7 @@ void MainWindow::onTranslationError(const QString &errorMessage)
         showError("翻译失败：" + errorMessage);
     }
     
-    LOG_USER_ACTION("翻译失败", errorMessage);
+    LOG_INFO(QString("翻译失败 - %1").arg(errorMessage));
 }
 
 void MainWindow::onSetApiClicked()
@@ -450,9 +450,9 @@ void MainWindow::onSetApiClicked()
     
     showInfo("API设置已保存并生效");
     
-    LOG_USER_ACTION("API设置", "设置并保存API密钥");
-    LOG_SETTINGS_CHANGE("appId", "", appId);
-    LOG_SETTINGS_CHANGE("secretKey", "", secretKey);
+    LOG_INFO("API设置 - 设置并保存API密钥");
+    LOG_INFO(QString("appId: %1***").arg(appId.left(4)));
+    LOG_INFO("secretKey: ******");
 }
 
 void MainWindow::onTestApiClicked()
@@ -473,7 +473,7 @@ void MainWindow::onTestApiClicked()
     m_testApiButton->setText("测试中...");
     m_statusLabel->setText("正在测试API连接...");
     
-    LOG_USER_ACTION("API测试", "开始测试API连接");
+    LOG_INFO("API测试 - 开始测试API连接");
     
     // 测试翻译"你好"为英文
     m_translator->translateText("你好", "zh", "en");
@@ -486,7 +486,7 @@ void MainWindow::onSwapLanguagesClicked()
     
     // 避免交换自动检测
     if (fromText == "自动检测") {
-        LOG_WARNING("尝试交换自动检测语言", "MainWindow");
+        LOG_WARNING("尝试交换自动检测语言");
         showInfo("自动检测模式无法交换语言");
         return;
     }
@@ -494,13 +494,13 @@ void MainWindow::onSwapLanguagesClicked()
     m_fromLanguageCombo->setCurrentText(toText);
     m_toLanguageCombo->setCurrentText(fromText);
     
-    LOG_USER_ACTION("语言交换", QString("从 %1 交换到 %2").arg(fromText).arg(toText));
-    LOG_DEBUG("语言选择已交换", "MainWindow");
+    LOG_INFO(QString("语言交换 - 从 %1 交换到 %2").arg(fromText).arg(toText));
+    LOG_DEBUG("语言选择已交换");
 }
 
 void MainWindow::loadSettings()
 {
-    LOG_DEBUG("开始加载设置", "MainWindow");
+    LOG_DEBUG("开始加载设置");
     
     // 加载API设置
     QString appId = m_settings->value("appId", "").toString();
@@ -512,7 +512,7 @@ void MainWindow::loadSettings()
     // 设置到翻译器
     if (!appId.isEmpty() && !secretKey.isEmpty()) {
         m_translator->setApiCredentials(appId, secretKey);
-        LOG_INFO("API设置已加载", "MainWindow");
+        LOG_INFO("API设置已加载");
     }
     
     // 加载语言设置
@@ -530,12 +530,12 @@ void MainWindow::loadSettings()
         m_toLanguageCombo->setCurrentIndex(toIndex);
     }
     
-    LOG_DEBUG("设置加载完成", "MainWindow");
+    LOG_DEBUG("设置加载完成");
 }
 
 void MainWindow::saveSettings()
 {
-    LOG_DEBUG("开始保存设置", "MainWindow");
+    LOG_DEBUG("开始保存设置");
     
     // 保存语言设置
     QString fromLang = m_fromLanguageCombo->currentData().toString();
@@ -544,7 +544,7 @@ void MainWindow::saveSettings()
     m_settings->setValue("fromLanguage", fromLang);
     m_settings->setValue("toLanguage", toLang);
     
-    LOG_DEBUG("设置保存完成", "MainWindow");
+    LOG_DEBUG("设置保存完成");
 }
 
 QString MainWindow::getLanguageCode(const QString &languageName)
@@ -567,12 +567,12 @@ QString MainWindow::getLanguageName(const QString &languageCode)
 
 void MainWindow::showError(const QString &message)
 {
-    LOG_ERROR(QString("显示错误对话框: %1").arg(message), "MainWindow");
+    LOG_ERROR(QString("显示错误对话框: %1").arg(message));
     QMessageBox::critical(this, "错误", message);
 }
 
 void MainWindow::showInfo(const QString &message)
 {
-    LOG_INFO(QString("显示信息对话框: %1").arg(message), "MainWindow");
+    LOG_INFO(QString("显示信息对话框: %1").arg(message));
     QMessageBox::information(this, "提示", message);
 } 

--- a/src/translator.cpp
+++ b/src/translator.cpp
@@ -11,12 +11,12 @@ Translator::Translator(QObject *parent)
     : QObject(parent)
     , m_networkManager(new QNetworkAccessManager(this))
 {
-    LOG_INFO("翻译器初始化完成", "Translator");
+    LOG_INFO("翻译器初始化完成");
 }
 
 Translator::~Translator()
 {
-    LOG_INFO("翻译器销毁", "Translator");
+    LOG_INFO("翻译器销毁");
 }
 
 void Translator::setApiCredentials(const QString &appId, const QString &secretKey)
@@ -24,7 +24,7 @@ void Translator::setApiCredentials(const QString &appId, const QString &secretKe
     m_appId = appId;
     m_secretKey = secretKey;
     
-    LOG_SETTINGS_CHANGE("API凭据", "设置新的API凭据", "App ID: " + appId.left(4) + "***");
+    LOG_INFO(QString("设置新的API凭据 - App ID: %1***").arg(appId.left(4)));
 }
 
 bool Translator::isApiConfigured() const
@@ -34,18 +34,21 @@ bool Translator::isApiConfigured() const
 
 void Translator::translateText(const QString &text, const QString &fromLang, const QString &toLang)
 {
-    LOG_TRANSLATION_START(text, fromLang, toLang);
+    LOG_INFO(QString("开始翻译 - 文本长度: %1, 从: %2, 到: %3")
+             .arg(text.length()).arg(fromLang).arg(toLang));
     
     if (!isApiConfigured()) {
         QString errorMsg = "请先配置百度翻译API密钥";
-        LOG_TRANSLATION_ERROR(text, errorMsg, fromLang, toLang);
+        LOG_ERROR(QString("翻译失败 - 文本长度: %1, 错误: %2")
+                  .arg(text.length()).arg(errorMsg));
         emit translationError(errorMsg);
         return;
     }
 
     if (text.trimmed().isEmpty()) {
         QString errorMsg = "请输入要翻译的文本";
-        LOG_TRANSLATION_ERROR(text, errorMsg, fromLang, toLang);
+        LOG_ERROR(QString("翻译失败 - 文本长度: %1, 错误: %2")
+                  .arg(text.length()).arg(errorMsg));
         emit translationError(errorMsg);
         return;
     }
@@ -65,7 +68,8 @@ void Translator::translateText(const QString &text, const QString &fromLang, con
     url.setQuery(query);
 
     QString params = query.toString();
-    LOG_API_CALL(url.toString(), params);
+    LOG_DEBUG(QString("API调用 - URL: %1, 参数长度: %2")
+              .arg(url.toString()).arg(params.length()));
 
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
@@ -80,7 +84,7 @@ void Translator::translateText(const QString &text, const QString &fromLang, con
     connect(reply, &QNetworkReply::errorOccurred,
             this, &Translator::onNetworkError);
             
-    LOG_INFO("网络请求已发送", "Translator");
+    LOG_INFO("网络请求已发送");
 }
 
 QString Translator::generateSignature(const QString &query, const QString &salt, 
@@ -90,14 +94,15 @@ QString Translator::generateSignature(const QString &query, const QString &salt,
     QByteArray hash = QCryptographicHash::hash(signStr.toUtf8(), QCryptographicHash::Md5);
     QString signature = hash.toHex();
     
-    LOG_DEBUG(QString("生成签名 - 原文长度: %1, 签名: %2...").arg(signStr.length()).arg(signature.left(8)), "Translator");
+    LOG_DEBUG(QString("生成签名 - 原文长度: %1, 签名: %2...")
+              .arg(signStr.length()).arg(signature.left(8)));
     return signature;
 }
 
 void Translator::onTranslationFinished(QNetworkReply *reply)
 {
     if (!reply) {
-        LOG_ERROR("无法获取网络响应对象", "Translator");
+        LOG_ERROR("无法获取网络响应对象");
         return;
     }
 
@@ -105,8 +110,7 @@ void Translator::onTranslationFinished(QNetworkReply *reply)
 
     if (reply->error() != QNetworkReply::NoError) {
         QString errorMsg = "网络请求失败: " + reply->errorString();
-        LOG_TRANSLATION_ERROR("", errorMsg, "", "");
-        LOG_API_RESPONSE("", false);
+        LOG_ERROR(QString("翻译失败: %1").arg(errorMsg));
         emit translationError(errorMsg);
         return;
     }
@@ -114,8 +118,7 @@ void Translator::onTranslationFinished(QNetworkReply *reply)
     QByteArray data = reply->readAll();
     QString response = QString::fromUtf8(data);
     
-    LOG_API_RESPONSE(response, true);
-    LOG_DEBUG(QString("收到API响应，长度: %1").arg(response.length()), "Translator");
+    LOG_DEBUG(QString("API响应 - 成功, 长度: %1").arg(response.length()));
     
     parseTranslationResult(data);
 }
@@ -124,7 +127,7 @@ void Translator::onNetworkError(QNetworkReply::NetworkError error)
 {
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     if (!reply) {
-        LOG_ERROR("无法获取网络错误响应对象", "Translator");
+        LOG_ERROR("无法获取网络错误响应对象");
         return;
     }
 
@@ -147,7 +150,7 @@ void Translator::onNetworkError(QNetworkReply::NetworkError error)
         break;
     }
 
-    LOG_ERROR(QString("网络错误: %1").arg(errorMsg), "Translator");
+    LOG_ERROR(QString("网络错误: %1").arg(errorMsg));
     emit translationError(errorMsg);
 }
 
@@ -158,7 +161,7 @@ void Translator::parseTranslationResult(const QByteArray &data)
     
     if (parseError.error != QJsonParseError::NoError) {
         QString errorMsg = "解析响应数据失败: " + parseError.errorString();
-        LOG_TRANSLATION_ERROR("", errorMsg, "", "");
+        LOG_ERROR(QString("翻译失败: %1").arg(errorMsg));
         emit translationError(errorMsg);
         return;
     }
@@ -186,7 +189,7 @@ void Translator::parseTranslationResult(const QByteArray &data)
         default: userFriendlyMsg = QString("API错误 %1: %2").arg(errorCode).arg(errorMsg); break;
         }
         
-        LOG_TRANSLATION_ERROR("", userFriendlyMsg, "", "");
+        LOG_ERROR(QString("翻译失败: %1").arg(userFriendlyMsg));
         emit translationError(userFriendlyMsg);
         return;
     }
@@ -199,13 +202,14 @@ void Translator::parseTranslationResult(const QByteArray &data)
             QString translatedText = firstResult["dst"].toString();
             QString detectedLang = obj["from"].toString();
             
-            LOG_TRANSLATION_SUCCESS("", translatedText, "", "", detectedLang);
+            LOG_INFO(QString("翻译成功 - 检测语言: %1, 译文长度: %2")
+                     .arg(detectedLang).arg(translatedText.length()));
             emit translationFinished(translatedText, detectedLang);
             return;
         }
     }
 
     QString errorMsg = "无法解析翻译结果";
-    LOG_TRANSLATION_ERROR("", errorMsg, "", "");
+    LOG_ERROR(QString("翻译失败: %1").arg(errorMsg));
     emit translationError(errorMsg);
 } 


### PR DESCRIPTION
## Summary
- drop module argument and extra logging helpers
- include file, line and thread information in each log message
- remove translation macros and update usages

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574f680ed88331871f1d5e1d7b79fc