### PR TITLE
Add system tray support

### DIFF
--- a/Translator.pro
+++ b/Translator.pro
@@ -25,6 +25,10 @@ HEADERS += \
     src/config.h \
     src/logger.h
 
+# 资源文件
+RESOURCES += \
+    resources/resources.qrc
+
 # UI文件
 FORMS += \
     ui/mainwindow.ui
@@ -35,7 +39,7 @@ DESTDIR = $$PWD/bin
 # Windows特定配置
 win32 {
     # Windows特定配置
-    # RC_ICONS = resources/icon.ico
+    RC_ICONS = resources/icon.ico
     # VERSION = 1.0.0.0
     QMAKE_TARGET_COMPANY = "Translator"
     QMAKE_TARGET_PRODUCT = "Translator"

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>icon.ico</file>
+    </qresource>
+</RCC>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -16,6 +16,9 @@
 #include <QSettings>
 #include <QCoreApplication>
 #include <QGuiApplication>
+#include <QSystemTrayIcon>
+#include <QMenu>
+#include <QAction>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -35,6 +38,7 @@ MainWindow::MainWindow(QWidget *parent)
     setupConnections();
     loadSettings();
     updateLanguageComboBoxes();
+    createTrayIcon();
     
     // 设置窗口属性
     setWindowTitle("百度翻译工具");
@@ -575,4 +579,46 @@ void MainWindow::showInfo(const QString &message)
 {
     LOG_INFO(QString("显示信息对话框: %1").arg(message));
     QMessageBox::information(this, "提示", message);
-} 
+}
+
+void MainWindow::createTrayIcon()
+{
+    m_trayIcon = new QSystemTrayIcon(QIcon(":/icon.ico"), this);
+
+    m_trayMenu = new QMenu(this);
+    m_showAction = new QAction(tr("显示"), this);
+    m_exitAction = new QAction(tr("退出"), this);
+
+    m_trayMenu->addAction(m_showAction);
+    m_trayMenu->addSeparator();
+    m_trayMenu->addAction(m_exitAction);
+
+    m_trayIcon->setContextMenu(m_trayMenu);
+    m_trayIcon->setToolTip(tr("Translator"));
+    m_trayIcon->show();
+
+    connect(m_trayIcon, &QSystemTrayIcon::activated,
+            this, &MainWindow::onTrayActivated);
+    connect(m_showAction, &QAction::triggered,
+            this, &MainWindow::onShowTriggered);
+    connect(m_exitAction, &QAction::triggered,
+            this, &MainWindow::onExitTriggered);
+}
+
+void MainWindow::onTrayActivated(QSystemTrayIcon::ActivationReason reason)
+{
+    if (reason == QSystemTrayIcon::Trigger) {
+        onShowTriggered();
+    }
+}
+
+void MainWindow::onShowTriggered()
+{
+    this->showNormal();
+    this->activateWindow();
+}
+
+void MainWindow::onExitTriggered()
+{
+    qApp->quit();
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -10,6 +10,9 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QLineEdit>
+#include <QSystemTrayIcon>
+#include <QMenu>
+#include <QAction>
 #include "translator.h"
 
 QT_BEGIN_NAMESPACE
@@ -33,6 +36,9 @@ private slots:
     void onSetApiClicked();
     void onTestApiClicked();
     void onSwapLanguagesClicked();
+    void onTrayActivated(QSystemTrayIcon::ActivationReason reason);
+    void onShowTriggered();
+    void onExitTriggered();
 
 private:
     void setupUi();
@@ -44,6 +50,7 @@ private:
     QString getLanguageName(const QString &languageCode);
     void showError(const QString &message);
     void showInfo(const QString &message);
+    void createTrayIcon();
 
     // UI组件
     QWidget *m_centralWidget;
@@ -83,6 +90,12 @@ private:
     
     // 设置
     QSettings *m_settings;
+
+    // 系统托盘
+    QSystemTrayIcon *m_trayIcon;
+    QMenu *m_trayMenu;
+    QAction *m_showAction;
+    QAction *m_exitAction;
 };
 
 #endif // MAINWINDOW_H 


### PR DESCRIPTION
## Summary
- show tray icon with menu actions using `icon.ico`
- load tray resources via `resources.qrc`
- reference qrc and Windows icon in project file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857541abeb08331968fdc04d80e177a