### PR TITLE
Implement tray minimization on close

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QAction>
+#include <QCloseEvent>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -39,10 +40,14 @@ MainWindow::MainWindow(QWidget *parent)
     loadSettings();
     updateLanguageComboBoxes();
     createTrayIcon();
-    
+
     // 设置窗口属性
     setWindowTitle("百度翻译工具");
     setMinimumSize(600, 500);
+    Qt::WindowFlags flags = windowFlags();
+    flags &= ~Qt::WindowMinimizeButtonHint;
+    flags &= ~Qt::WindowMaximizeButtonHint;
+    setWindowFlags(flags);
     
     // 居中显示窗口
     QScreen *screen = QGuiApplication::primaryScreen();
@@ -607,7 +612,7 @@ void MainWindow::createTrayIcon()
 
 void MainWindow::onTrayActivated(QSystemTrayIcon::ActivationReason reason)
 {
-    if (reason == QSystemTrayIcon::Trigger) {
+    if (reason == QSystemTrayIcon::DoubleClick) {
         onShowTriggered();
     }
 }
@@ -621,4 +626,17 @@ void MainWindow::onShowTriggered()
 void MainWindow::onExitTriggered()
 {
     qApp->quit();
+}
+
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    if (m_trayIcon && m_trayIcon->isVisible()) {
+        hide();
+        m_trayIcon->showMessage(tr("Translator"),
+                               tr("应用已最小化到托盘，双击图标以重新打开"),
+                               QSystemTrayIcon::Information, 2000);
+        event->ignore();
+    } else {
+        event->accept();
+    }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,9 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
 private slots:
     void onTranslateClicked();
     void onTranslationFinished(const QString &translatedText, const QString &detectedLang);


### PR DESCRIPTION
## Summary
- hide main window instead of exiting when the user clicks the close button
- restrict maximize/minimize buttons
- require double‑clicking the tray icon to reopen the window

## Testing
- `qmake Translator.pro -o Makefile` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68575688b8c48331b7c7e635eafa31e9